### PR TITLE
LPS-84666 portal-search: Add fields for every language supported by the group or company when indexing and searching.

### DIFF
--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/tags/search/test/AssetTagNamesMultiLanguageSearchTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/tags/search/test/AssetTagNamesMultiLanguageSearchTest.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.workflow.WorkflowThreadLocal;
@@ -117,6 +118,47 @@ public class AssetTagNamesMultiLanguageSearchTest {
 			});
 
 		assertSearch(tag, locale);
+	}
+
+	@Test
+	public void testEnglishJapaneseTags() throws Exception {
+		String usTag = "automobiles";
+
+		String japanTag = "自動車";
+
+		Group group = _userSearchFixture.addGroup(
+			new GroupBlueprint() {
+				{
+					defaultLocale = LocaleUtil.US;
+					availableLocales = Arrays.asList(
+						LocaleUtil.JAPAN, LocaleUtil.US);
+				}
+			});
+
+		_fileEntrySearchFixture.addFileEntry(
+			new FileEntryBlueprint() {
+				{
+					assetTagNames = new String[] {japanTag};
+					fileName = RandomTestUtil.randomString();
+					groupId = group.getGroupId();
+					title = RandomTestUtil.randomString();
+					userId = getAdminUserId(group);
+				}
+			});
+
+		_fileEntrySearchFixture.addFileEntry(
+			new FileEntryBlueprint() {
+				{
+					assetTagNames = new String[] {usTag};
+					fileName = RandomTestUtil.randomString();
+					groupId = group.getGroupId();
+					title = RandomTestUtil.randomString();
+					userId = getAdminUserId(group);
+				}
+			});
+
+		assertSearch(usTag, Locale.JAPAN);
+		assertSearch(japanTag, Locale.US);
 	}
 
 	@Test

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/query/QueryHelper.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/query/QueryHelper.java
@@ -26,6 +26,10 @@ import com.liferay.portal.kernel.search.SearchContext;
 @ProviderType
 public interface QueryHelper {
 
+	public void addSearchGroupLocalizedTerms(
+		BooleanQuery booleanQuery, SearchContext searchContext,
+		String fieldPrefix, boolean like);
+
 	public void addSearchLocalizedTerm(
 		BooleanQuery searchQuery, SearchContext searchContext, String field,
 		boolean like);

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/query/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/query/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/contributor/query/AssetCategoryTitlesKeywordQueryContributor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/contributor/query/AssetCategoryTitlesKeywordQueryContributor.java
@@ -17,9 +17,6 @@ package com.liferay.portal.search.internal.contributor.query;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.Localization;
-import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.search.query.QueryHelper;
 import com.liferay.portal.search.spi.model.query.contributor.KeywordQueryContributor;
 import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
@@ -42,28 +39,9 @@ public class AssetCategoryTitlesKeywordQueryContributor
 		SearchContext searchContext =
 			keywordQueryContributorHelper.getSearchContext();
 
-		Localization localization = getLocalization();
-
-		queryHelper.addSearchTerm(
-			booleanQuery, searchContext,
-			localization.getLocalizedName(
-				Field.ASSET_CATEGORY_TITLES,
-				LocaleUtil.toLanguageId(searchContext.getLocale())),
-			false);
+		queryHelper.addSearchGroupLocalizedTerms(
+			booleanQuery, searchContext, Field.ASSET_CATEGORY_TITLES, false);
 	}
-
-	protected Localization getLocalization() {
-
-		// See LPS-72507 and LPS-76500
-
-		if (localization != null) {
-			return localization;
-		}
-
-		return LocalizationUtil.getLocalization();
-	}
-
-	protected Localization localization;
 
 	@Reference
 	protected QueryHelper queryHelper;

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/contributor/query/AssetTagNamesKeywordQueryContributor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/contributor/query/AssetTagNamesKeywordQueryContributor.java
@@ -17,9 +17,6 @@ package com.liferay.portal.search.internal.contributor.query;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.Localization;
-import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.search.query.QueryHelper;
 import com.liferay.portal.search.spi.model.query.contributor.KeywordQueryContributor;
 import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
@@ -42,28 +39,9 @@ public class AssetTagNamesKeywordQueryContributor
 		SearchContext searchContext =
 			keywordQueryContributorHelper.getSearchContext();
 
-		Localization localization = getLocalization();
-
-		queryHelper.addSearchTerm(
-			booleanQuery, searchContext,
-			localization.getLocalizedName(
-				Field.ASSET_TAG_NAMES,
-				LocaleUtil.toLanguageId(searchContext.getLocale())),
-			false);
+		queryHelper.addSearchGroupLocalizedTerms(
+			booleanQuery, searchContext, Field.ASSET_TAG_NAMES, false);
 	}
-
-	protected Localization getLocalization() {
-
-		// See LPS-72507 and LPS-76500
-
-		if (localization != null) {
-			return localization;
-		}
-
-		return LocalizationUtil.getLocalization();
-	}
-
-	protected Localization localization;
 
 	@Reference
 	protected QueryHelper queryHelper;

--- a/modules/apps/users-admin/users-admin-test-util/src/main/java/com/liferay/users/admin/test/util/search/GroupBlueprint.java
+++ b/modules/apps/users-admin/users-admin-test-util/src/main/java/com/liferay/users/admin/test/util/search/GroupBlueprint.java
@@ -14,6 +14,7 @@
 
 package com.liferay.users.admin.test.util.search;
 
+import java.util.List;
 import java.util.Locale;
 
 /**
@@ -21,10 +22,15 @@ import java.util.Locale;
  */
 public class GroupBlueprint {
 
+	public List<Locale> getAvailableLocales() {
+		return availableLocales;
+	}
+
 	public Locale getDefaultLocale() {
 		return defaultLocale;
 	}
 
+	protected List<Locale> availableLocales;
 	protected Locale defaultLocale;
 
 }

--- a/modules/apps/users-admin/users-admin-test-util/src/main/java/com/liferay/users/admin/test/util/search/UserSearchFixture.java
+++ b/modules/apps/users-admin/users-admin-test-util/src/main/java/com/liferay/users/admin/test/util/search/UserSearchFixture.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
@@ -58,10 +59,15 @@ public class UserSearchFixture {
 		Group group = addGroup();
 
 		Locale locale = groupBlueprint.getDefaultLocale();
+		List<Locale> availableLocales = groupBlueprint.getAvailableLocales();
 
 		if (locale != null) {
+			if (ListUtil.isEmpty(availableLocales)) {
+				availableLocales = Arrays.asList(locale);
+			}
+
 			GroupTestUtil.updateDisplaySettings(
-				group.getGroupId(), null, locale);
+				group.getGroupId(), availableLocales, locale);
 		}
 
 		return group;

--- a/modules/apps/users-admin/users-admin-test-util/src/main/resources/com/liferay/users/admin/test/util/search/packageinfo
+++ b/modules/apps/users-admin/users-admin-test-util/src/main/resources/com/liferay/users/admin/test/util/search/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0


### PR DESCRIPTION
Hey Brian! This is the fix I guess has an outdated test. The test is Search#SearchBlogsEntryTag as seen in https://testray.liferay.com/reports/production/logs/test-1-1/1539269722441/test-portal-acceptance-pullrequest(master)/3702/functional-tomcat90-mysql57-jdk8/1/0/LocalFile.Search_SearchBlogsEntryTag/index.html.gz. Thanks!