### PR TITLE
LPS-203913 Get localClusterConnectionId directly from CrossClusterReplicationConfiguration to avoid dependency on ClusterExecutor

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchConnectionManager.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchConnectionManager.java
@@ -7,9 +7,6 @@ package com.liferay.portal.search.elasticsearch7.internal.connection;
 
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.cluster.ClusterExecutor;
-import com.liferay.portal.kernel.cluster.ClusterNode;
 import com.liferay.portal.kernel.concurrent.SystemExecutorServiceUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -22,8 +19,6 @@ import com.liferay.portal.search.elasticsearch7.internal.configuration.Elasticse
 import com.liferay.portal.search.elasticsearch7.internal.configuration.OperationModeResolver;
 import com.liferay.portal.search.elasticsearch7.internal.connection.constants.ConnectionConstants;
 import com.liferay.portal.search.elasticsearch7.internal.helper.SearchLogHelperUtil;
-
-import java.net.InetAddress;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -171,46 +166,23 @@ public class ElasticsearchConnectionManager
 	}
 
 	public String getLocalClusterConnectionId() {
-		ClusterNode localClusterNode = _clusterExecutor.getLocalClusterNode();
-
 		CrossClusterReplicationConfigurationHelper
 			currentCrossClusterReplicationConfigurationHelper =
 				_crossClusterReplicationConfigurationHelperSnapshot.get();
 
-		if (localClusterNode == null) {
-			if (currentCrossClusterReplicationConfigurationHelper == null) {
-				return null;
-			}
-
-			List<String> localClusterConnectionIds =
-				currentCrossClusterReplicationConfigurationHelper.
-					getLocalClusterConnectionIds();
-
-			if (localClusterConnectionIds.isEmpty()) {
-				return null;
-			}
-
-			return localClusterConnectionIds.get(0);
-		}
-
-		InetAddress portalInetAddress = localClusterNode.getPortalInetAddress();
-
-		if ((portalInetAddress == null) ||
-			(currentCrossClusterReplicationConfigurationHelper == null)) {
-
+		if (currentCrossClusterReplicationConfigurationHelper == null) {
 			return null;
 		}
 
-		Map<String, String> localClusterConnectionConfigurations =
+		List<String> localClusterConnectionIds =
 			currentCrossClusterReplicationConfigurationHelper.
-				getLocalClusterConnectionIdsMap();
+				getLocalClusterConnectionIds();
 
-		String localClusterNodeHostName =
-			portalInetAddress.getHostName() + StringPool.COLON +
-				localClusterNode.getPortalPort();
+		if (localClusterConnectionIds.isEmpty()) {
+			return null;
+		}
 
-		return localClusterConnectionConfigurations.get(
-			localClusterNodeHostName);
+		return localClusterConnectionIds.get(0);
 	}
 
 	@Override
@@ -470,9 +442,6 @@ public class ElasticsearchConnectionManager
 		_crossClusterReplicationConfigurationHelperSnapshot = new Snapshot<>(
 			ElasticsearchConnectionManager.class,
 			CrossClusterReplicationConfigurationHelper.class, null, true);
-
-	@Reference
-	private ClusterExecutor _clusterExecutor;
 
 	private final Map<String, Supplier<ElasticsearchConnection>>
 		_elasticsearchConnectionSuppliers = new ConcurrentHashMap<>();

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchConnectionManagerTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchConnectionManagerTest.java
@@ -229,6 +229,9 @@ public class ElasticsearchConnectionManagerTest {
 		_elasticsearchConnectionManager.addElasticsearchConnection(
 			elasticsearchConnection);
 
+		_elasticsearchConnectionManager.getElasticsearchConnection(
+			elasticsearchConnection.getConnectionId());
+
 		Mockito.verify(
 			elasticsearchConnection
 		).isActive();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/CrossClusterReplicationES7.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/CrossClusterReplicationES7.testcase
@@ -669,4 +669,103 @@ definition {
 		SearchResults.viewSearchResultNotPresent(searchTerm = "DM");
 	}
 
+	@priority = 5
+	test SmokeWithPortalClusteringEnabled {
+		property app.server.bundles.size = "1";
+		property cluster.enabled = "true";
+		property osgi.module.configuration.file.names = "com.liferay.portal.bundle.blacklist.internal.configuration.BundleBlacklistConfiguration.config";
+		property osgi.module.configurations = "blacklistBundleSymbolicNames=\"com.liferay.portal.search.tuning.rankings.web\"";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		JSONDocument.addFile(
+			dmDocumentDescription = "DM Description",
+			dmDocumentTitle = "DM Title 1",
+			groupName = "Guest");
+
+		CrossClusterReplication.setupCrossClusterReplication();
+
+		SearchAdministration.openSearchAdmin();
+
+		AssertTextEquals(
+			locator1 = "Portlet#HEADER",
+			value1 = "Search");
+
+		AssertTextEquals.assertPartialText(
+			key_connectionId = "__REMOTE__",
+			locator1 = "SearchAdmin#CLUSTER_NAME",
+			value1 = "LiferayElasticsearchCluster");
+
+		AssertTextEquals.assertPartialText(
+			key_connectionId = "localcluster",
+			locator1 = "SearchAdmin#CLUSTER_NAME",
+			value1 = "LiferayElasticsearchClusterTwo");
+
+		Navigator.openURL();
+
+		SearchPage.searchEmbedded(searchTerm = "DM");
+
+		SearchResults.viewSearchResults(
+			searchAssetTitle = "DM Title 1",
+			searchAssetType = "Document");
+
+		AntCommands.runCommand("build-test-elasticsearch7.xml", "stop-elasticsearch -Delasticsearch.bundle.number=1");
+
+		SearchAdministration.openSearchAdmin();
+
+		AssertTextEquals(
+			locator1 = "Portlet#HEADER",
+			value1 = "Search");
+
+		AssertTextEquals.assertPartialText(
+			key_connectionId = "localcluster",
+			locator1 = "SearchAdmin#CLUSTER_NAME",
+			value1 = "LiferayElasticsearchClusterTwo");
+
+		AssertTextEquals.assertPartialText(
+			locator1 = "Message#ERROR",
+			value1 = "Connection refused");
+
+		AssertElementNotPresent(
+			key_connectionId = "__REMOTE__",
+			locator1 = "SearchAdmin#CLUSTER_NAME");
+
+		Navigator.openURL();
+
+		SearchPage.searchEmbedded(searchTerm = "DM");
+
+		SearchResults.viewSearchResults(
+			searchAssetTitle = "DM Title 1",
+			searchAssetType = "Document");
+
+		AntCommands.runCommand("build-test-elasticsearch7.xml", "start-elasticsearch-node -Delasticsearch.bundle.number=1");
+
+		AntCommands.runCommand("build-test-elasticsearch7.xml", "stop-elasticsearch -Delasticsearch.bundle.number=2");
+
+		SearchAdministration.openSearchAdmin();
+
+		AssertTextEquals(
+			locator1 = "Portlet#HEADER",
+			value1 = "Search");
+
+		AssertTextEquals.assertPartialText(
+			key_connectionId = "__REMOTE__",
+			locator1 = "SearchAdmin#CLUSTER_NAME",
+			value1 = "LiferayElasticsearchCluster");
+
+		AssertTextEquals.assertPartialText(
+			locator1 = "Message#ERROR",
+			value1 = "Connection refused");
+
+		AssertElementNotPresent(
+			key_connectionId = "localcluster",
+			locator1 = "SearchAdmin#CLUSTER_NAME");
+
+		Navigator.openURL();
+
+		SearchPage.searchEmbedded(searchTerm = "DM");
+
+		SearchResults.viewSearchResultNotPresent(searchTerm = "DM");
+	}
+
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-203913
https://liferay.atlassian.net/browse/LPS-203978

This PR was run through `search` test suite here: https://github.com/shuyangzhou/liferay-portal/pull/11327#issuecomment-1854687436